### PR TITLE
Vim support - coc.nvim and ALE

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,36 @@ This vscode extension is in development and might be lacking features you know w
 This extension contributes the following settings:
 
 * `elmLS.trace.server`: enable/disable trace logging of client and server communication
+
+## Editor Support
+
+### Vim
+
+#### coc.nvim
+To enable support with [coc.nvim](https://github.com/neoclide/coc.nvim), run `:CocConfig` and add the language server config below.
+
+```
+{
+  "languageserver": {
+    "elm-ls": {
+      "command": "elm-ls",
+      "args": ["--stdio"],
+      "filetypes": ["elm"],
+      "rootPatterns": ["elm.json"],
+      "initializationOptions": {
+        "runtime": "node"
+      },
+      "settings": {}
+    }
+  }
+}
+```
+
+#### ALE
+For [ALE](https://github.com/w0rp/ale) support.
+
+| Package Manager | Command |
+|---|---|
+|[Vim-Plug](https://github.com/junegunn/vim-plug)|`Plug 'antew/vim-elm-language-server'`|
+|[Vundle](https://github.com/VundleVim/Vundle.vim)|`Plugin 'antew/vim-elm-language-server'`|
+|[Pathogen](https://github.com/tpope/vim-pathogen)|<pre>cd ~/.vim/bundle<br>git clone https://github.com/antew/vim-elm-language-server.git</pre>|

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "workspaceContains:**/elm.json"
   ],
   "main": "./client/out/extension",
+  "bin": {
+    "elm-ls": "server/out/index.js"
+  },
   "contributes": {
     "languages": [
       {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,6 +8,7 @@ import {
 import { ILanguageServer } from "./server";
 import { rebuildTreeSitter } from "./util/rebuilder";
 
+export type Runtime = "node" | "electron";
 const connection: IConnection = createConnection(ProposedFeatures.all);
 
 connection.onInitialize(
@@ -17,10 +18,12 @@ connection.onInitialize(
         connection.console.info(
           "Rebuilding tree-sitter for local Electron version",
         );
+        const runtime: Runtime =
+          params.initializationOptions.runtime || "electron";
         const rebuildResult: [
           void | Error,
           void | Error
-        ] = await rebuildTreeSitter(connection.console);
+        ] = await rebuildTreeSitter(connection.console, runtime);
         for (const result of rebuildResult) {
           if (result) {
             connection.console.error("Rebuild failed!");

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import {
   createConnection,
   IConnection,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -29,7 +29,12 @@ export class Server implements ILanguageServer {
   constructor(connection: Connection, params: InitializeParams) {
     this.calculator = new CapabilityCalculator(params.capabilities);
     if (params.workspaceFolders && params.workspaceFolders.length > 0) {
-      const elmWorkspace = URI.parse(params.initializationOptions.elmWorkspace);
+      // Make sure the path ends with a slash to match how elmWorkspace works in VSCode
+      const elmWorkspaceFallback =
+        params.rootUri && params.rootUri.replace(/\/?$/, "/");
+      const elmWorkspace = URI.parse(
+        params.initializationOptions.elmWorkspace || elmWorkspaceFallback,
+      );
       const forest = new Forest();
       const workspaceFolder = params.workspaceFolders[0];
       connection.console.info(`Initializing Elm language server for workspace

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -32,22 +32,14 @@ export class Server implements ILanguageServer {
 
     const elmWorkspaceFallback =
       // Add a trailing slash if not present
-      params.rootUri && URI.parse(params.rootUri.replace(/\/?$/, "/"));
-    const elmWorkspace =
-      URI.parse(params.initializationOptions.elmWorkspace) ||
-      elmWorkspaceFallback;
+      params.rootUri && params.rootUri.replace(/\/?$/, "/");
+    const elmWorkspace = URI.parse(
+      params.initializationOptions.elmWorkspace || elmWorkspaceFallback,
+    );
 
-    if (params.workspaceFolders && params.workspaceFolders.length > 0) {
-      // Make sure the path ends with a slash to match how elmWorkspace works in VSCode
-      const workspaceFolder = params.workspaceFolders[0];
-      connection.console.info(`Initializing Elm language server for workspace
- ${workspaceFolder.uri} using ${elmWorkspace}`);
+    if (elmWorkspace) {
+      connection.console.info(`[elm-ls] initializing - folder=${elmWorkspace}`);
       this.registerProviders(connection, forest, elmWorkspace);
-    } else if (elmWorkspaceFallback) {
-      connection.console.info(
-        `Initializing Elm language server for folder ${elmWorkspaceFallback}`,
-      );
-      this.registerProviders(connection, forest, elmWorkspaceFallback);
     } else {
       connection.console.info(`No workspace.`);
     }


### PR DESCRIPTION
This lets the language server work with Vim or ALE

Some notes on the implementation:

- I had to add a way to figure out whether to download the node or electron version of tree-sitter-elm, I think there has to be a better way to detect this but I haven't come up with anything.  I tried with the `is-electron` package but I think it always reports false when the server is started through vscode because it is really running in node at that point and communicating through ipc/stdio.
- When running with `coc.nvim` it wasn't as easy to get the `elmWorkspace` folder into the initialization options, but it does provide a `rootUri`, so I added that as a fallback when `elmWorkspace` is unavailable.
- I found that ALE doesn't support workspace folders, I saw it was only using the first folder in a workspace for now so I simplified the code a bit there to only use the workspace folder or the one taken from the `rootUri`

I updated the readme with info on how to enable it for the different editors.

Here's how the warnings appear in Vim with coc.vim

![image](https://user-images.githubusercontent.com/1693421/56874036-e66fa280-6a04-11e9-94c1-f064a23ca248.png)


